### PR TITLE
fix ruamel.yaml on 0.14.X for now

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,4 +7,4 @@ detox
 coverage
 flake8
 psutil
-ruamel.yaml
+ruamel.yaml<0.15

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ def readfile(filename):
 #requiers = readfile ('requirements.txt')
 requiers = """
 cloudmesh.evegenie
-ruamel.yaml
+ruamel.yaml<0.15
 psutil
 pygments
 tox


### PR DESCRIPTION
Thank you for using ruamel.yaml.

There will be API changes in the 0.15+ versions, that might lead to warnings that 
your user could see.
Therefore please release a version of your package with this change, so that it will not
automatically take the latest ruamel.yaml release.
