### PR TITLE
Scope Section update

### DIFF
--- a/docs/objects.tex
+++ b/docs/objects.tex
@@ -99,37 +99,30 @@ usable for the implementation of Big Data Architectures.
 \subsection{Scope and Objectives of the Reference Architecture
   Subgroup}
 
-The NBD-PWG Standards Roadmap Subgroup focused on forming a community
-of interest from industry, academia, and government, with the goal of
-developing a standards roadmap. The Subgroup's approach included the
-following: (Ross, 2013)
+Reference architectures provide “an authoritative source of information about a specific subject area that guides and constrains the instantiations of multiple architectures and solutions.”   Reference architectures generally serve as a foundation for solution architectures and may also be used for comparison and alignment of instantiations of architectures and solutions. 
+ 
+The goal of the NBD-PWG Reference Architecture Subgroup is to develop an open reference architecture for Big Data that achieves the following objectives:
 
+ \begin{itemize}
+\item Provides a common language for the various stakeholders
+\item Encourages adherence to common standards, specifications, and patterns
+\item Provides consistent methods for implementation of technology to solve similar problem sets
+\item Illustrates and improves understanding of the various Big Data components, processes, and systems, in the context of a vendor- and technology-agnostic Big Data conceptual model
+\item Provides a technical reference for U.S. government departments, agencies, and other consumers to understand, discuss, categorize, and compare Big Data solutions
+\item Facilitates analysis of candidate standards for interoperability, portability, reusability, and extendibility
+ \end{itemize}
+
+The NBDRA is a high-level conceptual model crafted to serve as a tool to facilitate open discussion of the requirements, design structures, and operations inherent in Big Data. The NBDRA is intended to facilitate the understanding of the operational intricacies in Big Data. It does not represent the system architecture of a specific Big Data system, but rather is a tool for describing, discussing, and developing system-specific architectures using a common framework of reference. The model is not tied to any specific vendor products, services, or reference implementation, nor does it define prescriptive solutions that inhibit innovation. 
+
+The NBDRA does not address the following:
 \begin{itemize}
-\item Collaborate with the other four NBD-PWG subgroups;
-\item Review products of the other four subgroups including
-  taxonomies, use cases, general requirements, and reference
-  architecture;
-\item Gain an understanding of what standards are available or under
-  development that may apply Big Data; Perform a standards, gap
-  analysis and document the findings;
-\item Document vision and recommendations for future standards
-  activities;
-\item Identify possible barriers that may delay or prevent adoption of
-  Big Data; and
-\item Identify a few areas where new standards could have a
-  significant impact.
-\end{itemize}
+\item Detailed specifications for any organization’s operational systems
+\item Detailed specifications of information exchanges or services
+\item Recommendations or standards for integration of infrastructure products
+\end {itemize}
 
-The goals of the Subgroup will be realized throughout the three
-planned phases of the NBD-PWG work, as outlined in Section 1.1
-\ref{??}.
+The goals of the Subgroup will be realized throughout the three planned phases of the NBD-PWG work, as outlined in Section 1.1 \ref{S:r-background}.
 
-Within the multitude of standards applicable to data and information
-technology, the Subgroup focused on standards that: 1) apply to
-situations encountered in Big Data; 2) facilitate interfaces between
-NBDRA components (difference between Implementer [encoder] or User
-[decoder] may be nonexistent), 3) facilitate handling Big Data
-characteristics, and 4) represent a fundamental function
 
 \subsection{Report Production}
 


### PR DESCRIPTION
The previous text in the Scope of the Reference Architecture Subgroup was from Volume 9. It was deleted. Text from Volume 6 (also from the RA Subgroup) was added.