### PR TITLE
Conflict: Delete Report Production text

### DIFF
--- a/docs/objects.tex
+++ b/docs/objects.tex
@@ -133,28 +133,12 @@ characteristics, and 4) represent a fundamental function
 
 \subsection{Report Production}
 
-NBDIF: Volume 8, Interfaces is one of nine volumes, whose overall aims
-are to define and specify interfaces to implement the Big Data
-Reference Architecture.
 
-173 The NBDIF: Volume 8, interafces from discussions during the weekly
-NBD-PWG 174 conference calls. Topics included in this volume began to
-take form in Phase 2 of the NBD-PWG work and this 175 volume
-represents the groundwork for additional content planned for Phase 3.
-
-176 During the discussions, the NBD-PWG identified the need to specify
-a variety of interfaces including:
 
 TBD 
 
 
-include the list here. The Standards Roadmap Subgroup will continue to
-develop these and possibly other topics during Phase 3. The current
-version reflects the breadth of knowledge of the Subgroup members. The
-public’s participation in Phase 3 of the NBD-PWG work is encouraged.
-To achieve technical and high quality document content, this document
-will go through public comments period along with NIST internal
-review.
+
 
 
 \subsection{Report Structure}


### PR DESCRIPTION
The text in the Report Production section was from Volume 9. It was deleted.