### PR TITLE
Added text: NBDRA Interface Requirements

### DIFF
--- a/docs/objects.tex
+++ b/docs/objects.tex
@@ -169,8 +169,59 @@ Version 3 of this document include the following:
 
 TBD
 
+\newpage 
 
 \section{NBDRA Interface Requirements}
+
+The development of a Big Data reference architecture requires a thorough understanding of current
+techniques, issues, and concerns. To this end, the NBD-PWG collected use cases to gain an 
+understanding of current applications of Big Data, conducted a survey of reference architectures 
+to understand commonalities within Big Data architectures in use, developed a taxonomy to understand
+and organize the information collected, and reviewed existing technologies and trends relevant 
+to Big Data. The results of these NBD-PWG activities were used in the development of the NBDRA 
+(Figure~\ref{F:architecture}) and the interfaces presented herein. Detailed descriptions of these activities can 
+be found in the other volumes of the {\it NBDIF}. 
+
+\begin{figure*}[h]\centering
+\includegraphics[width=1.1\textwidth]{images/vol8-nbdra}
+\caption{NIST Big Data Reference Architecture (NBDRA)}
+\label{F:architecture}
+\end{figure*}
+
+
+This vendor-neutral, technology- and infrastructure-agnostic conceptual model, the NBDRA, is shown 
+in Figure~\ref{F:architecture} and represents a Big Data system comprised of five logical functional components 
+connected by interoperability interfaces (i.e., services). Two fabrics envelop the components, 
+representing the interwoven nature of management and security and privacy with all five of the 
+components. These two fabrics provide services and functionality to the five main roles in the areas
+specific to Big Data and are crucial to any Big Data solution.
+Note: None of the terminology or diagrams in these documents is intended to be normative or to imply
+any business or deployment model. The terms {\it provider} and {\it consumer} as used are descriptive 
+of general roles and are meant to be informative in nature.
+
+The NBDRA is organized around five major roles and multiple sub-roles aligned along two axes 
+representing the two Big Data value chains: the Information Value (horizontal axis) and the Information
+Technology (IT; vertical axis). Along the Information Value axis, the value is created by data collection,
+integration, analysis, and applying the results following the value chain. Along the IT axis, the value
+is created by providing networking, infrastructure, platforms, application tools, and other IT services
+for hosting of and operating the Big Data in support of required data applications. At the intersection
+of both axes is the Big Data Application Provider role, indicating that data analytics and its 
+implementation provide the value to Big Data stakeholders in both value chains. The term provider 
+as part of the Big Data Application Provider and Bid Data Framework Provider is there to indicate 
+that those roles provide or implement specific activities and functions within the system. It does 
+not designate a service model or business entity.
+
+The DATA arrows in Figure 2 show the flow of data between the system’s main roles. Data flows 
+between the roles either physically (i.e., by value) or by providing its location and the means
+to access it (i.e., by reference). The SW arrows show transfer of software tools for processing of
+Big Data {\it in situ}. The Service Use arrows represent software programmable interfaces. While the
+main focus of the NBDRA is to represent the run-time environment, all three types of communications 
+or transactions can happen in the configuration phase as well. Manual agreements (e.g., service-level
+agreements) and human interactions that may exist throughout the system are not shown in the NBDRA.
+
+Detailed information on the NBDRA conceptual model is presented in the 
+{\it NBDIF: Volume 6, Reference Architecture} document.
+
 
 Before we start outlining the specific interfaces, we introduce
 general requirements and explain how we define the interfaces while


### PR DESCRIPTION
Added text to the NBDRA Interface Requirements section to provide the readers more information on the NBDRA in case they do not read Volume 6. The text was copied verbatim from Volume 6.

Also added \newpage before the section since we start first level headers on a new page in the word documents.