### PR TITLE
Updates to Schema and Prerequisites sections

### DIFF
--- a/docs/objects.tex
+++ b/docs/objects.tex
@@ -1730,22 +1730,22 @@ defined in this document.
 
 \section{Cloudmesh Rest}\label{s:cloudmesh-rest}
 
-Cloudmesh Rest is a refernce implementattion for the NBDRA. It
-allows to define automatically a REST service based on the objects
-specified by the NBDRA document. In collaboration with other cloudmesh
+Cloudmesh Rest is a reference implementation for the NBDRA. It
+allows for automatic definition of a REST service based on the objects
+specified by the NBDRA. In collaboration with other cloudmesh
 components it allows easy interaction with hybrid clouds and the
-creation of user managed big data services. 
+creation of user managed Big Data services. 
 
-\subsection{Prerequistis}\label{prerequistis}
+\subsection{Prerequisites}\label{prerequistis}
 
-The preriquisits for Cloudmesh REST are Python 2.7.13 or 3.6.1
-it can easily be installed on a variety of systems (at this time we
-have only tried ubuntu greater 16.04 and OSX Sierra. However, it would
-naturally be possible to also port it to Windows. The instalation
-instruction in this document are not complete and we recommend to
-refer to the cloudmesh manuals which are under development. The goal
-will be to make the instalation (after your system is set up for
-developing python) as simple as 
+The prerequisiits for cloudmesh Rest are Python 2.7.13 or 3.6.1.
+It can easily be installed on a variety of systems (at this time
+only ubuntu greater 16.04 and OSX Sierra have been tested). However, it would
+naturally be possible to also port it to Windows. At the time of publication, the installation
+instructions in this document are not complete. The reader is
+referred to the cloudmesh manuals, which are under development. The goal
+will be to make the installation (after the system is set up for
+developing Python) as simple as the following:
 
 \begin{verbatim}
     pip install cloudmesh.rest


### PR DESCRIPTION
Updates to Schema and Prerequisites sections

Here again I am assuming that cloudmesh is not capitalized. Please change if this is not correct.
Also, the rest portion of cloudmesh rest was presented both as Rest and REST. I opted for Rest since the majority of the uses were as Rest. We can change the capitalization of both cloud mesh and rest but we should be consistent throughout the document.